### PR TITLE
Add mako.directories value

### DIFF
--- a/production.ini
+++ b/production.ini
@@ -16,6 +16,8 @@ pyramid.default_locale_name = en
 # wsgi server configuration
 ###
 
+mako.directories = webdnsmasq:templates
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
So that it knows where to look for the templates.  Without it, an error is thrown.
